### PR TITLE
feat: basic structure libraryUser service

### DIFF
--- a/src/main/java/com/box/library/user/LibraryUserService.java
+++ b/src/main/java/com/box/library/user/LibraryUserService.java
@@ -1,0 +1,13 @@
+package com.box.library.user;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class LibraryUserService {
+
+    private final LibraryUserRepository repository;
+
+    public LibraryUserService(LibraryUserRepository repository) {
+        this.repository = repository;
+    }
+}


### PR DESCRIPTION
Como o repository foi criado como LibraryUserRepository eu resolvi seguir o padrão, mas se for o caso, podemos refatorar para deixar só o modelo como LibraryUser